### PR TITLE
docs: clarify rai-checklist-cli context and close the integration seam

### DIFF
--- a/04_integration_demo/README.md
+++ b/04_integration_demo/README.md
@@ -1,6 +1,8 @@
 # Module 4: Integration Demo
 
-This module connects the TPU batch evaluator (Module 2) to rai-checklist-cli's existing report formats. It runs a before/after comparison to make the throughput difference tangible.
+This module connects the TPU batch evaluator (Module 2) to [rai-checklist-cli](https://github.com/ByteanAtomResearch/rai-checklist-cli) -- a CLI tool for generating and validating Responsible AI compliance checklists across the ML lifecycle. rai-checklist-cli produces (and consumes) Markdown, YAML, and JSON reports covering stages like data privacy, ethical considerations, and deployment monitoring.
+
+The demo shows the throughput gap between sequential and batch evaluation, then writes results in the exact formats rai-checklist-cli already understands so you can validate them with the existing tool.
 
 ## What it does
 
@@ -30,6 +32,17 @@ python 04_integration_demo/integration_demo.py \
 ```
 
 Add `--skip-sequential` to skip the simulated baseline and just run the TPU evaluation.
+
+## Connecting the output to rai-checklist-cli
+
+After `make demo`, the generated YAML report can be validated directly with rai-checklist-cli:
+
+```bash
+pip install rai-checklist-cli
+rai-checklist validate results/integration/evaluation_report.yaml
+```
+
+The Markdown report follows the same checklist format that `rai-checklist generate -f md` produces, so it can be dropped into any project that already uses rai-checklist-cli for audit trails.
 
 ## This is a demo
 

--- a/04_integration_demo/integration_demo.py
+++ b/04_integration_demo/integration_demo.py
@@ -284,6 +284,10 @@ def main(args: argparse.Namespace) -> None:
     console.print(f"  JSON:     {json_path}")
     console.print(f"  Markdown: {md_path}")
     console.print(f"  YAML:     {yaml_path}")
+    console.print()
+    console.print("[dim]To validate the YAML report with rai-checklist-cli:")
+    console.print("  pip install rai-checklist-cli")
+    console.print(f"  rai-checklist validate {yaml_path}[/dim]")
 
     # ── Step 4: Before/after comparison ──────────────────────────────────
     console.print()

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ A hands-on, reproducible tutorial for ML practitioners who want to run Responsib
 
 > **Heads up on Colab quotas**: free-tier Colab gates TPU access pretty aggressively. If you see "Cannot connect to TPU backend due to usage limits," you've exhausted your daily allocation. Wait 24 hours for the rolling reset, switch Google accounts, or consider [Kaggle Notebooks](https://www.kaggle.com/code) which offer 30 hours/week of TPU v3-8 free. The tutorial code itself runs on any TPU generation; only the provisioning changes.
 
-This tutorial uses [rai-checklist-cli](https://github.com/ByteanAtomResearch/rai-checklist-cli) as a real-world case study and shows how a sequential, single-record evaluation workflow transforms into a mass-parallelized batch pipeline that processes 50 records across 3 heuristics in a single forward pass.
+This tutorial uses [rai-checklist-cli](https://github.com/ByteanAtomResearch/rai-checklist-cli) as a real-world case study. That package is a CLI tool for generating and validating Responsible AI compliance checklists (Markdown, YAML, JSON) across the AI/ML lifecycle. It covers stages like data privacy, ethical considerations, and deployment monitoring, and its YAML/JSON output can gate CI/CD pipelines.
+
+The tutorial shows how the sequential, per-record evaluation pattern that rai-checklist-cli expects transforms into a mass-parallelized batch pipeline that processes 50 records across 3 heuristics in a single forward pass, then feeds the results directly back into rai-checklist-cli's existing report formats.
 
 ## Why this matters
 
@@ -37,6 +39,7 @@ flowchart LR
         JSON[batch_results.json]
         MD[evaluation_report.md]
         YAML[evaluation_report.yaml]
+        RAI[rai-checklist-cli<br/>validate / report]
     end
 
     subgraph Serve[Online API Server]
@@ -51,6 +54,8 @@ flowchart LR
     VLLM --> JSON
     JSON --> MD
     JSON --> YAML
+    MD --> RAI
+    YAML --> RAI
     JSONL -.-> CLIENT
     SERVER -.-> JSON
 


### PR DESCRIPTION
Follows on from PR #2. One commit was pushed after that PR merged.

### Changes
- **README.md**: intro now explains what rai-checklist-cli actually is (a CLI tool for generating/validating RAI checklists across the ML lifecycle that can gate CI/CD pipelines), not just a link
- **README.md architecture diagram**: `rai-checklist-cli` added as a terminal node; MD and YAML outputs wire to it so the full pipeline is visible end-to-end
- **04_integration_demo/README.md**: opening describes what rai-checklist-cli does for readers who don't already know it; new "Connecting the output to rai-checklist-cli" section with the concrete `rai-checklist validate` command
- **04_integration_demo/integration_demo.py**: prints the validate command at runtime after generating reports so the seam closes visibly

Co-Authored-By: Oz <oz-agent@warp.dev>