### PR TITLE
fix(notebook): add transformers upgrade to resolve gemma4 ValidationError

### DIFF
--- a/notebooks/tutorial_colab.ipynb
+++ b/notebooks/tutorial_colab.ipynb
@@ -15,25 +15,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Install JAX with the TPU extra so libtpu is wired up before vllm-tpu loads.\n",
-    "# This must come before the vllm-tpu install.\n",
-    "!pip install -q \"jax[tpu]\" -f https://storage.googleapis.com/jax-releases/libtpu_releases.html\n",
-    "!pip install -q \"vllm-tpu>=0.13.0\" rich\n",
-    "\n",
-    "# Smoke test: confirm JAX sees the TPU before we go further.\n",
-    "import jax\n",
-    "\n",
-    "tpu_devices = [d for d in jax.devices() if d.platform == \"tpu\"]\n",
-    "print(f\"JAX platform: {jax.default_backend()}\")\n",
-    "print(f\"TPU devices found: {len(tpu_devices)}\")\n",
-    "if not tpu_devices:\n",
-    "    raise RuntimeError(\n",
-    "        \"No TPU devices found. Go to Runtime -> Change runtime type \"\n",
-    "        \"and select 'TPU v2' as the hardware accelerator, then rerun.\"\n",
-    "    )\n",
-    "print(\"TPU ready. Proceed to Step 2.\")"
-   ]
+   "source": "# Install JAX with the TPU extra so libtpu is wired up before vllm-tpu loads.\n# This must come before the vllm-tpu install.\n!pip install -q \"jax[tpu]\" -f https://storage.googleapis.com/jax-releases/libtpu_releases.html\n!pip install -q \"vllm-tpu>=0.13.0\" rich\n# Gemma 4 requires transformers >= 4.50. Colab ships an older version;\n# upgrading it is safe alongside vllm-tpu.\n!pip install -q --upgrade transformers\n\n# Smoke test: confirm JAX sees the TPU before we go further.\nimport jax\n\ntpu_devices = [d for d in jax.devices() if d.platform == \"tpu\"]\nprint(f\"JAX platform: {jax.default_backend()}\")\nprint(f\"TPU devices found: {len(tpu_devices)}\")\nif not tpu_devices:\n    raise RuntimeError(\n        \"No TPU devices found. Go to Runtime -> Change runtime type \"\n        \"and select 'TPU v2' as the hardware accelerator, then rerun.\"\n    )\nprint(\"TPU ready. Proceed to Step 2.\")"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
Fixes Colab batch inference failure reported during live testing.

**Error:** `ValidationError: model type 'gemma4' but Transformers does not recognize this architecture`

**Root cause:** Colab ships an older version of `transformers` that doesn't have the `gemma4` architecture class registered. Gemma 4 requires `transformers >= 4.50`.


**Note:** The v5e-1 hardware is correct and sufficient for `gemma-4-E2B-it`. This error is purely a library version issue, not a hardware issue.
